### PR TITLE
Fix car, now keep the items into array

### DIFF
--- a/src/js/product.js
+++ b/src/js/product.js
@@ -1,11 +1,20 @@
-import { setLocalStorage } from './utils.mjs';
+import { getLocalStorage, setLocalStorage } from './utils.mjs';
 import ProductData from './ProductData.mjs';
 
 const dataSource = new ProductData('tents');
 
 function addProductToCart(product) {
-  setLocalStorage('so-cart', product);
+  let cartItems = getLocalStorage('so-cart');
+
+  // me seguro de que sea un array
+  if (!Array.isArray(cartItems)) {
+    cartItems = [];
+  }
+
+  cartItems.push(product);
+  setLocalStorage('so-cart', cartItems);
 }
+
 // add to cart button event handler
 async function addToCartHandler(e) {
   const product = await dataSource.findProductById(e.target.dataset.id);


### PR DESCRIPTION
Fix: Cart now correctly accumulates multiple products

- Added validation to ensure `getLocalStorage("so-cart")` returns an array
- Prevented cart from being overwritten on each add-to-cart action
- Verified in DevTools that multiple products are stored correctly
- Code structure remains consistent with instructor's original implementation